### PR TITLE
Implement order management in PHP version

### DIFF
--- a/gruzovozoff/static/js/form.js
+++ b/gruzovozoff/static/js/form.js
@@ -1,13 +1,13 @@
 // simple phone input mask for +7(999)-999-99-99
 window.addEventListener('DOMContentLoaded', function() {
   const phone = document.querySelector('input[name="phone"]');
-  if (!phone) return;
-  phone.addEventListener('input', function(e) {
-    let digits = phone.value.replace(/\D/g, '').substring(0, 10);
-    let formatted = '+7(';
-    if (digits.length >= 3) {
-      formatted += digits.slice(0,3) + ')-';
-      if (digits.length >= 6) {
+  if (phone) {
+    phone.addEventListener('input', function(e) {
+      let digits = phone.value.replace(/\D/g, '').substring(0, 10);
+      let formatted = '+7(';
+      if (digits.length >= 3) {
+        formatted += digits.slice(0,3) + ')-';
+        if (digits.length >= 6) {
         formatted += digits.slice(3,6) + '-';
         if (digits.length >= 8) {
           formatted += digits.slice(6,8) + '-';
@@ -20,7 +20,17 @@ window.addEventListener('DOMContentLoaded', function() {
       }
     } else {
       formatted += digits;
-    }
-    phone.value = formatted;
-  });
+      }
+      phone.value = formatted;
+    });
+  }
+
+  const cargoSelect = document.getElementById('cargo_type');
+  if (cargoSelect) {
+    cargoSelect.addEventListener('change', function() {
+      if (cargoSelect.value === 'Мусор') {
+        alert('Стоимость заказа увеличится из-за необходимости утилизации.');
+      }
+    });
+  }
 });

--- a/gruzovozoff/templates/admin.html
+++ b/gruzovozoff/templates/admin.html
@@ -1,13 +1,46 @@
 {% extends 'base.html' %}
 {% block content %}
 <h2>Все заявки</h2>
+<form method="get" action="{{ url_for('admin_panel') }}">
+    <label>Статус:
+        <select name="status">
+            <option value="" {% if not status_filter %}selected{% endif %}>Все</option>
+            <option value="Новая" {% if status_filter=='Новая' %}selected{% endif %}>Новая</option>
+            <option value="В работе" {% if status_filter=='В работе' %}selected{% endif %}>В работе</option>
+            <option value="Выполнено" {% if status_filter=='Выполнено' %}selected{% endif %}>Выполнено</option>
+            <option value="Отменена" {% if status_filter=='Отменена' %}selected{% endif %}>Отменена</option>
+        </select>
+    </label>
+    <button type="submit">Фильтр</button>
+</form>
 {% if orders %}
 <table>
-<tr><th>ID</th><th>Пользователь</th><th>Дата</th><th>Вес</th><th>Габариты</th><th>Тип</th><th>Откуда</th><th>Куда</th><th></th></tr>
+<tr><th>ID</th><th>Пользователь</th><th>Дата</th><th>Вес</th><th>Габариты</th><th>Тип</th><th>Откуда</th><th>Куда</th><th>Статус</th><th>Действия</th></tr>
 {% for o in orders %}
 <tr>
-<td>{{ o.id }}</td><td>{{ o.user_id }}</td><td>{{ o.datetime }}</td><td>{{ o.weight }}</td><td>{{ o.size }}</td><td>{{ o.cargo_type }}</td><td>{{ o.from_addr }}</td><td>{{ o.to_addr }}</td>
-<td><form method="post" action="{{ url_for('delete_order', order_id=o.id) }}" style="display:inline"><button type="submit">Удалить</button></form></td>
+<td>{{ o.id }}</td>
+<td>{{ o.user_id }}</td>
+<td>{{ o.datetime }}</td>
+<td>{{ o.weight }}</td>
+<td>{{ o.size }}</td>
+<td>{{ o.cargo_type }}</td>
+<td>{{ o.from_addr }}</td>
+<td>{{ o.to_addr }}</td>
+<td>{{ o.status }}</td>
+<td>
+    <form method="post" action="{{ url_for('update_status', order_id=o.id) }}" style="display:inline">
+        <select name="status">
+            <option value="Новая" {% if o.status=='Новая' %}selected{% endif %}>Новая</option>
+            <option value="В работе" {% if o.status=='В работе' %}selected{% endif %}>В работе</option>
+            <option value="Выполнено" {% if o.status=='Выполнено' %}selected{% endif %}>Выполнено</option>
+            <option value="Отменена" {% if o.status=='Отменена' %}selected{% endif %}>Отменена</option>
+        </select>
+        <button type="submit">Обновить</button>
+    </form>
+    <form method="post" action="{{ url_for('delete_order', order_id=o.id) }}" style="display:inline">
+        <button type="submit">Удалить</button>
+    </form>
+</td>
 </tr>
 {% endfor %}
 </table>

--- a/gruzovozoff/templates/create.html
+++ b/gruzovozoff/templates/create.html
@@ -5,7 +5,17 @@
     <p>Дата и время: <input name="datetime" type="datetime-local" required></p>
     <p>Вес (кг): <input name="weight" type="number" min="0" step="0.01" required></p>
     <p>Габариты: <input name="size" required></p>
-    <p>Тип груза: <input name="cargo_type" required></p>
+    <p>Тип груза:
+        <select name="cargo_type" id="cargo_type">
+            <option value="Хрупкое">Хрупкое</option>
+            <option value="Скоропортящееся">Скоропортящееся</option>
+            <option value="Требуется рефрижератор">Требуется рефрижератор</option>
+            <option value="Животные">Животные</option>
+            <option value="Жидкость">Жидкость</option>
+            <option value="Мебель">Мебель</option>
+            <option value="Мусор">Мусор</option>
+        </select>
+    </p>
     <p>Адрес отправления: <input name="from_addr" required></p>
     <p>Адрес доставки: <input name="to_addr" required></p>
     <p><button type="submit">Отправить</button></p>

--- a/gruzovozoff/templates/orders.html
+++ b/gruzovozoff/templates/orders.html
@@ -3,10 +3,29 @@
 <h2>Мои заявки</h2>
 {% if orders %}
 <table>
-<tr><th>ID</th><th>Дата</th><th>Вес</th><th>Габариты</th><th>Тип</th><th>Откуда</th><th>Куда</th></tr>
+<tr>
+<th>ID</th><th>Дата</th><th>Вес</th><th>Габариты</th><th>Тип</th><th>Откуда</th><th>Куда</th><th>Статус</th><th>Отзыв</th>
+</tr>
 {% for o in orders %}
 <tr>
-<td>{{ o.id }}</td><td>{{ o.datetime }}</td><td>{{ o.weight }}</td><td>{{ o.size }}</td><td>{{ o.cargo_type }}</td><td>{{ o.from_addr }}</td><td>{{ o.to_addr }}</td>
+<td>{{ o.id }}</td>
+<td>{{ o.datetime }}</td>
+<td>{{ o.weight }}</td>
+<td>{{ o.size }}</td>
+<td>{{ o.cargo_type }}</td>
+<td>{{ o.from_addr }}</td>
+<td>{{ o.to_addr }}</td>
+<td>{{ o.status }}</td>
+<td>
+    {% if o.status == 'Выполнено' and not o.review %}
+        <form method="post" action="{{ url_for('add_review', order_id=o.id) }}">
+            <input type="text" name="review" required>
+            <button type="submit">Оставить отзыв</button>
+        </form>
+    {% else %}
+        {{ o.review or '' }}
+    {% endif %}
+</td>
 </tr>
 {% endfor %}
 </table>

--- a/php_version/static/js/form.js
+++ b/php_version/static/js/form.js
@@ -1,10 +1,10 @@
 // simple phone input mask for +7(999)-999-99-99
 window.addEventListener('DOMContentLoaded', function() {
   const phone = document.querySelector('input[name="phone"]');
-  if (!phone) return;
-  phone.addEventListener('input', function(e) {
-    let digits = phone.value.replace(/\D/g, '').substring(0, 10);
-    let formatted = '+7(';
+  if (phone) {
+    phone.addEventListener('input', function(e) {
+      let digits = phone.value.replace(/\D/g, '').substring(0, 10);
+      let formatted = '+7(';
     if (digits.length >= 3) {
       formatted += digits.slice(0,3) + ')-';
       if (digits.length >= 6) {
@@ -21,6 +21,16 @@ window.addEventListener('DOMContentLoaded', function() {
     } else {
       formatted += digits;
     }
-    phone.value = formatted;
-  });
+      phone.value = formatted;
+    });
+  }
+
+  const cargoSelect = document.getElementById('cargo_type');
+  if (cargoSelect) {
+    cargoSelect.addEventListener('change', function() {
+      if (cargoSelect.value === 'Мусор') {
+        alert('Стоимость заказа увеличится из-за необходимости утилизации.');
+      }
+    });
+  }
 });

--- a/php_version/templates_php/admin.php
+++ b/php_version/templates_php/admin.php
@@ -1,7 +1,19 @@
 <h2>Все заявки</h2>
+<form method="get" action="?action=admin">
+    <label>Статус:
+        <select name="status">
+            <option value="" <?php if (!$status_filter) echo 'selected'; ?>>Все</option>
+            <option value="Новая" <?php if ($status_filter=='Новая') echo 'selected'; ?>>Новая</option>
+            <option value="В работе" <?php if ($status_filter=='В работе') echo 'selected'; ?>>В работе</option>
+            <option value="Выполнено" <?php if ($status_filter=='Выполнено') echo 'selected'; ?>>Выполнено</option>
+            <option value="Отменена" <?php if ($status_filter=='Отменена') echo 'selected'; ?>>Отменена</option>
+        </select>
+    </label>
+    <button type="submit">Фильтр</button>
+</form>
 <?php if ($orders): ?>
 <table>
-<tr><th>ID</th><th>Пользователь</th><th>Дата</th><th>Вес</th><th>Габариты</th><th>Тип</th><th>Откуда</th><th>Куда</th><th></th></tr>
+<tr><th>ID</th><th>Пользователь</th><th>Дата</th><th>Вес</th><th>Габариты</th><th>Тип</th><th>Откуда</th><th>Куда</th><th>Статус</th><th>Действия</th></tr>
 <?php foreach ($orders as $o): ?>
 <tr>
 <td><?= htmlspecialchars($o['id']) ?></td>
@@ -12,10 +24,20 @@
 <td><?= htmlspecialchars($o['cargo_type']) ?></td>
 <td><?= htmlspecialchars($o['from_addr']) ?></td>
 <td><?= htmlspecialchars($o['to_addr']) ?></td>
+<td><?= htmlspecialchars($o['status']) ?></td>
 <td>
-<form method="post" action="?action=delete&id=<?= $o['id'] ?>" style="display:inline">
-<button type="submit">Удалить</button>
-</form>
+    <form method="post" action="?action=update&id=<?= $o['id'] ?>" style="display:inline">
+        <select name="status">
+            <option value="Новая" <?= $o['status']=='Новая'?'selected':'' ?>>Новая</option>
+            <option value="В работе" <?= $o['status']=='В работе'?'selected':'' ?>>В работе</option>
+            <option value="Выполнено" <?= $o['status']=='Выполнено'?'selected':'' ?>>Выполнено</option>
+            <option value="Отменена" <?= $o['status']=='Отменена'?'selected':'' ?>>Отменена</option>
+        </select>
+        <button type="submit">Обновить</button>
+    </form>
+    <form method="post" action="?action=delete&id=<?= $o['id'] ?>" style="display:inline">
+        <button type="submit">Удалить</button>
+    </form>
 </td>
 </tr>
 <?php endforeach; ?>

--- a/php_version/templates_php/create.php
+++ b/php_version/templates_php/create.php
@@ -3,7 +3,17 @@
     <p>Дата и время: <input name="datetime" type="datetime-local" required></p>
     <p>Вес (кг): <input name="weight" type="number" min="0" step="0.01" required></p>
     <p>Габариты: <input name="size" required></p>
-    <p>Тип груза: <input name="cargo_type" required></p>
+    <p>Тип груза:
+        <select name="cargo_type" id="cargo_type">
+            <option value="Хрупкое">Хрупкое</option>
+            <option value="Скоропортящееся">Скоропортящееся</option>
+            <option value="Требуется рефрижератор">Требуется рефрижератор</option>
+            <option value="Животные">Животные</option>
+            <option value="Жидкость">Жидкость</option>
+            <option value="Мебель">Мебель</option>
+            <option value="Мусор">Мусор</option>
+        </select>
+    </p>
     <p>Адрес отправления: <input name="from_addr" required></p>
     <p>Адрес доставки: <input name="to_addr" required></p>
     <p><button type="submit">Отправить</button></p>

--- a/php_version/templates_php/orders.php
+++ b/php_version/templates_php/orders.php
@@ -1,7 +1,7 @@
 <h2>Мои заявки</h2>
 <?php if ($orders): ?>
 <table>
-<tr><th>ID</th><th>Дата</th><th>Вес</th><th>Габариты</th><th>Тип</th><th>Откуда</th><th>Куда</th></tr>
+<tr><th>ID</th><th>Дата</th><th>Вес</th><th>Габариты</th><th>Тип</th><th>Откуда</th><th>Куда</th><th>Статус</th><th>Отзыв</th></tr>
 <?php foreach ($orders as $o): ?>
 <tr>
 <td><?= htmlspecialchars($o['id']) ?></td>
@@ -11,6 +11,17 @@
 <td><?= htmlspecialchars($o['cargo_type']) ?></td>
 <td><?= htmlspecialchars($o['from_addr']) ?></td>
 <td><?= htmlspecialchars($o['to_addr']) ?></td>
+<td><?= htmlspecialchars($o['status']) ?></td>
+<td>
+    <?php if ($o['status'] === 'Выполнено' && empty($o['review'])): ?>
+    <form method="post" action="?action=review&id=<?= $o['id'] ?>">
+        <input type="text" name="review" required>
+        <button type="submit">Оставить отзыв</button>
+    </form>
+    <?php else: ?>
+        <?= htmlspecialchars($o['review'] ?? '') ?>
+    <?php endif; ?>
+</td>
 </tr>
 <?php endforeach; ?>
 </table>


### PR DESCRIPTION
## Summary
- support order `status` and `review` in PHP backend
- dropdown cargo type with trash warning
- users can review completed orders
- admin panel can filter and update order status

## Testing
- `python -m py_compile gruzovozoff/app.py`
- `php -l php_version/index.php`
- `php -l php_version/templates_php/admin.php`
- `php -l php_version/templates_php/create.php`
- `php -l php_version/templates_php/orders.php`


------
https://chatgpt.com/codex/tasks/task_e_68433a2ca730832788c2a0445eda8d23