### PR TITLE
Use MySQL in PHP version

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,4 +19,7 @@ python gruzovozoff/app.py
 php -S localhost:8000 -t php_version
 ```
 
+Файл `php_version/db_config.php` содержит параметры подключения к MySQL. Перед
+запуском создайте базу данных и при необходимости измените логин/пароль.
+
 После запуска PHP версия будет доступна на `http://localhost:8000`.

--- a/php_version/db_config.php
+++ b/php_version/db_config.php
@@ -1,0 +1,6 @@
+<?php
+return [
+    'dsn' => 'mysql:host=localhost;dbname=gruzovozoff;charset=utf8mb4',
+    'user' => 'root',
+    'password' => ''
+];

--- a/php_version/index.php
+++ b/php_version/index.php
@@ -1,37 +1,38 @@
 <?php
 session_start();
 
-$db = new PDO('sqlite:' . __DIR__ . '/../gruzovozoff/gruzovozoff.db');
+$config = require __DIR__ . '/db_config.php';
+$db = new PDO($config['dsn'], $config['user'], $config['password']);
 $db->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
 
 // Initialize tables
 $db->exec("CREATE TABLE IF NOT EXISTS users (
-    id INTEGER PRIMARY KEY AUTOINCREMENT,
-    username TEXT UNIQUE,
-    password_hash TEXT,
-    full_name TEXT,
-    phone TEXT,
-    email TEXT
-)");
+    id INT AUTO_INCREMENT PRIMARY KEY,
+    username VARCHAR(255) UNIQUE,
+    password_hash VARCHAR(255),
+    full_name VARCHAR(255),
+    phone VARCHAR(255),
+    email VARCHAR(255)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4");
 $db->exec("CREATE TABLE IF NOT EXISTS orders (
-    id INTEGER PRIMARY KEY AUTOINCREMENT,
-    user_id INTEGER,
-    datetime TEXT,
-    weight TEXT,
-    size TEXT,
-    cargo_type TEXT,
-    from_addr TEXT,
-    to_addr TEXT,
-    status TEXT DEFAULT 'Новая',
+    id INT AUTO_INCREMENT PRIMARY KEY,
+    user_id INT,
+    datetime DATETIME,
+    weight VARCHAR(255),
+    size VARCHAR(255),
+    cargo_type VARCHAR(255),
+    from_addr VARCHAR(255),
+    to_addr VARCHAR(255),
+    status VARCHAR(255) DEFAULT 'Новая',
     review TEXT
-)");
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4");
 
 // add new columns if database already existed
 $cols = [];
-$res = $db->query("PRAGMA table_info(orders)");
-foreach ($res as $row) { $cols[] = $row['name']; }
+$res = $db->query("SHOW COLUMNS FROM orders");
+foreach ($res as $row) { $cols[] = $row['Field']; }
 if (!in_array('status', $cols)) {
-    $db->exec("ALTER TABLE orders ADD COLUMN status TEXT DEFAULT 'Новая'");
+    $db->exec("ALTER TABLE orders ADD COLUMN status VARCHAR(255) DEFAULT 'Новая'");
 }
 if (!in_array('review', $cols)) {
     $db->exec("ALTER TABLE orders ADD COLUMN review TEXT");


### PR DESCRIPTION
## Summary
- switch PHP version from SQLite to MySQL
- store MySQL connection settings in `db_config.php`
- document the configuration file in the README

## Testing
- `php -l php_version/index.php` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684409be60888327af9cb69ce23173fb