### PR TITLE
Add modern glassmorphism UI for PHP version

### DIFF
--- a/php_version/orders_ajax.php
+++ b/php_version/orders_ajax.php
@@ -1,0 +1,39 @@
+<?php
+session_start();
+$config = require __DIR__ . '/db_config.php';
+$db = new PDO($config['dsn'], $config['user'], $config['password']);
+$db->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
+
+if (!isset($_SESSION['user_id'])) {
+    http_response_code(401);
+    echo 'Не авторизовано';
+    exit;
+}
+
+$stmt = $db->prepare('SELECT * FROM orders WHERE user_id = ?');
+$stmt->execute([$_SESSION['user_id']]);
+$orders = $stmt->fetchAll(PDO::FETCH_ASSOC);
+if ($orders) {
+    echo "<table><tr><th>ID</th><th>Дата</th><th>Вес</th><th>Габариты</th><th>Тип</th><th>Откуда</th><th>Куда</th><th>Статус</th><th>Отзыв</th></tr>";
+    foreach ($orders as $o) {
+        $id = htmlspecialchars($o['id']);
+        $datetime = htmlspecialchars($o['datetime']);
+        $weight = htmlspecialchars($o['weight']);
+        $size = htmlspecialchars($o['size']);
+        $type = htmlspecialchars($o['cargo_type']);
+        $from = htmlspecialchars($o['from_addr']);
+        $to = htmlspecialchars($o['to_addr']);
+        $status = htmlspecialchars($o['status']);
+        $review = '';
+        if ($o['status'] === 'Выполнено' && empty($o['review'])) {
+            $review = "<form method='post' action='?action=review&id=$id'><input type='text' name='review' required><button type='submit'>Оставить отзыв</button></form>";
+        } else {
+            $review = htmlspecialchars($o['review'] ?? '');
+        }
+        echo "<tr><td>$id</td><td>$datetime</td><td>$weight</td><td>$size</td><td>$type</td><td>$from</td><td>$to</td><td>$status</td><td>$review</td></tr>";
+    }
+    echo "</table>";
+} else {
+    echo '<p>Заявок нет</p>';
+}
+

--- a/php_version/static/css/style.css
+++ b/php_version/static/css/style.css
@@ -1,37 +1,43 @@
 :root {
-  --bg-color: #f7f7f7;
-  --container-bg: #fff;
-  --nav-bg: #2d6a4f;
-  --nav-text: #fff;
-  --text-color: #333;
-  --accent: #2d6a4f;
-  --accent-hover: #1b4332;
+  --bg-color: linear-gradient(135deg, #e2e8f0, #f8fafc);
+  --container-bg: rgba(255, 255, 255, 0.4);
+  --nav-bg: rgba(255, 255, 255, 0.25);
+  --nav-text: #111827;
+  --text-color: #1f2937;
+  --accent: #6366f1;
+  --accent-hover: #4f46e5;
+  --radius: 16px;
 }
 
 body {
-  font-family: 'Segoe UI', Tahoma, sans-serif;
-  background-color: var(--bg-color);
+  font-family: 'Poppins', 'Segoe UI', Tahoma, sans-serif;
+  background: var(--bg-color);
   color: var(--text-color);
   margin: 0;
   transition: background-color 0.3s, color 0.3s;
+  scroll-behavior: smooth;
 }
 
 body.dark {
-  --bg-color: #202124;
-  --container-bg: #303134;
-  --nav-bg: #111;
-  --nav-text: #ddd;
-  --text-color: #eee;
-  --accent: #5e8c61;
-  --accent-hover: #6bbf73;
+  --bg-color: linear-gradient(135deg, #0f172a, #1e293b);
+  --container-bg: rgba(48, 55, 70, 0.4);
+  --nav-bg: rgba(48, 55, 70, 0.25);
+  --nav-text: #e2e8f0;
+  --text-color: #f8fafc;
+  --accent: #8b5cf6;
+  --accent-hover: #7c3aed;
 }
 
 nav {
-  background-color: var(--nav-bg);
-  padding: 10px;
+  background: var(--nav-bg);
+  backdrop-filter: blur(12px);
+  -webkit-backdrop-filter: blur(12px);
+  padding: 10px 20px;
   display: flex;
   align-items: center;
   justify-content: space-between;
+  border-radius: var(--radius);
+  box-shadow: 0 4px 16px rgba(0,0,0,0.1);
 }
 
 nav .links {
@@ -43,11 +49,32 @@ nav .links {
 nav a {
   color: var(--nav-text);
   text-decoration: none;
-  font-weight: bold;
+  font-weight: 600;
+  position: relative;
+  padding: 6px;
+  transition: color 0.3s, transform 0.3s;
+}
+
+nav a::after {
+  content: '';
+  position: absolute;
+  left: 0;
+  bottom: 0;
+  width: 100%;
+  height: 2px;
+  background: var(--accent);
+  transform: scaleX(0);
+  transform-origin: left;
+  transition: transform 0.3s;
 }
 
 nav a:hover {
-  text-decoration: underline;
+  color: var(--accent);
+  transform: translateY(-2px);
+}
+
+nav a:hover::after {
+  transform: scaleX(1);
 }
 
 #theme-toggle {
@@ -56,59 +83,85 @@ nav a:hover {
   color: var(--nav-text);
   font-size: 1.2rem;
   cursor: pointer;
-  transition: color 0.3s;
+  transition: color 0.3s, transform 0.3s;
 }
 
 #theme-toggle:hover {
-  color: #ffeb3b;
+  color: var(--accent);
+  transform: rotate(20deg);
 }
 
 .container {
-  max-width: 800px;
-  margin: 30px auto;
+  max-width: 960px;
+  margin: 40px auto;
   background: var(--container-bg);
-  padding: 20px;
-  border-radius: 8px;
-  box-shadow: 0 2px 8px rgba(0,0,0,0.1);
-  transition: background-color 0.3s;
+  padding: 30px;
+  border-radius: var(--radius);
+  box-shadow: 0 4px 24px rgba(0, 0, 0, 0.1);
+  backdrop-filter: blur(20px);
+  -webkit-backdrop-filter: blur(20px);
+  transition: background-color 0.3s, transform 0.3s;
+}
+
+.container:hover {
+  transform: translateY(-2px);
 }
 
 input, select {
-  padding: 6px;
-  border-radius: 4px;
-  border: 1px solid #ccc;
+  padding: 10px;
+  border-radius: var(--radius);
+  border: none;
+  background: rgba(255, 255, 255, 0.6);
+  box-shadow: inset 0 2px 4px rgba(0,0,0,0.1);
   width: 100%;
   box-sizing: border-box;
+  font-size: 1rem;
 }
 
 table {
   width: 100%;
   border-collapse: collapse;
+  overflow: hidden;
+  border-radius: var(--radius);
 }
 
 table th, table td {
-  border: 1px solid #ccc;
-  padding: 8px;
+  border: 1px solid rgba(0,0,0,0.05);
+  padding: 12px 16px;
   text-align: left;
+  backdrop-filter: blur(4px);
 }
 
 button {
-  background: var(--accent);
+  background: linear-gradient(45deg, var(--accent), var(--accent-hover));
   color: #fff;
   border: none;
-  padding: 6px 12px;
+  padding: 10px 20px;
   cursor: pointer;
-  border-radius: 4px;
-  transition: background 0.3s;
+  border-radius: var(--radius);
+  box-shadow: 0 4px 12px rgba(0,0,0,0.1);
+  transition: transform 0.3s, box-shadow 0.3s;
 }
 
 button:hover {
-  background: var(--accent-hover);
+  transform: translateY(-3px);
+  box-shadow: 0 8px 16px rgba(0,0,0,0.15);
 }
 
 .error {
   color: red;
   margin-top: 10px;
+}
+
+.fade {
+  opacity: 0;
+  transform: translateY(30px);
+  transition: opacity 0.6s ease-out, transform 0.6s ease-out;
+}
+
+.fade.show {
+  opacity: 1;
+  transform: none;
 }
 
 form p {
@@ -122,7 +175,7 @@ form p {
   }
   .container {
     margin: 15px;
-    padding: 15px;
+    padding: 20px;
   }
   table th, table td {
     font-size: 14px;

--- a/php_version/static/js/ui.js
+++ b/php_version/static/js/ui.js
@@ -1,0 +1,23 @@
+// Additional UI interactions
+window.addEventListener('DOMContentLoaded', () => {
+  // intersection observer for fade-in elements
+  const observer = new IntersectionObserver(entries => {
+    entries.forEach(entry => {
+      if (entry.isIntersecting) {
+        entry.target.classList.add('show');
+      }
+    });
+  }, { threshold: 0.1 });
+  document.querySelectorAll('.fade').forEach(el => observer.observe(el));
+
+  const orders = document.getElementById('orders-dynamic');
+  if (orders) {
+    orders.innerHTML = '<p>Загрузка...</p>';
+    fetch('orders_ajax.php')
+      .then(r => r.text())
+      .then(html => {
+        orders.innerHTML = html;
+      });
+  }
+});
+

--- a/php_version/templates_php/admin.php
+++ b/php_version/templates_php/admin.php
@@ -1,5 +1,5 @@
-<h2>Все заявки</h2>
-<form method="get" action="index.php">
+<h2 class="fade">Все заявки</h2>
+<form method="get" action="index.php" class="fade">
     <input type="hidden" name="action" value="admin">
     <label>Статус:
         <select name="status">
@@ -13,7 +13,7 @@
     <button type="submit">Фильтр</button>
 </form>
 <?php if ($orders): ?>
-<table>
+<table class="fade">
 <tr><th>ID</th><th>Пользователь</th><th>Дата</th><th>Вес</th><th>Габариты</th><th>Тип</th><th>Откуда</th><th>Куда</th><th>Статус</th><th>Действия</th></tr>
 <?php foreach ($orders as $o): ?>
 <tr>
@@ -44,5 +44,5 @@
 <?php endforeach; ?>
 </table>
 <?php else: ?>
-<p>Заявок нет</p>
+<p class="fade">Заявок нет</p>
 <?php endif; ?>

--- a/php_version/templates_php/base.php
+++ b/php_version/templates_php/base.php
@@ -4,6 +4,9 @@
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <title>Грузовозофф</title>
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=Poppins:wght@400;600&display=swap" rel="stylesheet">
     <link rel="stylesheet" href="static/css/style.css">
 </head>
 <body>
@@ -23,9 +26,10 @@
     </div>
     <button id="theme-toggle" title="Сменить тему">🌙</button>
 </nav>
-<div class="container">
+<div class="container fade" id="main-container">
 <?php echo $content; ?>
 </div>
 <script src="static/js/form.js"></script>
+<script src="static/js/ui.js"></script>
 </body>
 </html>

--- a/php_version/templates_php/create.php
+++ b/php_version/templates_php/create.php
@@ -1,5 +1,5 @@
-<h2>Новая заявка</h2>
-<form method="post" action="?action=create">
+<h2 class="fade">Новая заявка</h2>
+<form method="post" action="?action=create" class="fade">
     <p>Дата и время: <input name="datetime" type="datetime-local" required></p>
     <p>Вес (кг): <input name="weight" type="number" min="0" step="0.01" required></p>
     <p>Габариты (Д×Ш×В, см):

--- a/php_version/templates_php/login.php
+++ b/php_version/templates_php/login.php
@@ -1,5 +1,5 @@
-<h2>Вход</h2>
-<form method="post" action="?action=login">
+<h2 class="fade">Вход</h2>
+<form method="post" action="?action=login" class="fade">
     <p>Логин: <input name="username" required></p>
     <p>Пароль: <input type="password" name="password" required></p>
     <p><button type="submit">Войти</button></p>

--- a/php_version/templates_php/orders.php
+++ b/php_version/templates_php/orders.php
@@ -1,6 +1,7 @@
 <h2>Мои заявки</h2>
+<div id="orders-dynamic">
 <?php if ($orders): ?>
-<table>
+<table class="fade">
 <tr><th>ID</th><th>Дата</th><th>Вес</th><th>Габариты</th><th>Тип</th><th>Откуда</th><th>Куда</th><th>Статус</th><th>Отзыв</th></tr>
 <?php foreach ($orders as $o): ?>
 <tr>
@@ -26,5 +27,6 @@
 <?php endforeach; ?>
 </table>
 <?php else: ?>
-<p>Заявок нет</p>
+<p class="fade">Заявок нет</p>
 <?php endif; ?>
+</div>

--- a/php_version/templates_php/register.php
+++ b/php_version/templates_php/register.php
@@ -1,5 +1,5 @@
-<h2>Регистрация</h2>
-<form method="post" action="?action=register">
+<h2 class="fade">Регистрация</h2>
+<form method="post" action="?action=register" class="fade">
     <p>Логин: <input name="username" required pattern="[А-Яа-яЁё]{6,}"></p>
     <p>Пароль: <input type="password" name="password" required minlength="6"></p>
     <p>ФИО: <input name="full_name" required pattern="[А-Яа-яЁё ]+"></p>


### PR DESCRIPTION
## Summary
- overhaul php_version styles with gradients, glass effects and animations
- load order list via ajax and show fade-in animations
- update templates to use new fonts and JS helpers
- add UI helper script and endpoint for dynamic order data

## Testing
- `python -m py_compile gruzovozoff/app.py`
- ⚠️ `php -l` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68440c92f1488327acf27b430f209409